### PR TITLE
Bugfix/293 numeric min max

### DIFF
--- a/__tests__/after.spec.ts
+++ b/__tests__/after.spec.ts
@@ -1,7 +1,7 @@
 import Validator from '../src/main'
 
 describe('after rule', () => {
-  it('should fail when the comparing attribute are greather', () => {
+  it('should fail when the comparing attribute are greater', () => {
     const validator = new Validator(
       { date: '1996-12-09', date2: '1995-08-09' },
       { date2: 'after:date' },

--- a/__tests__/max.spec.ts
+++ b/__tests__/max.spec.ts
@@ -62,17 +62,18 @@ describe('max validation rule', () => {
     expect(validator.passes()).toBeFalsy()
   })
 
-  it('should be passed when given string numeric', () => {
-    const validator = new Validator({ val: '12345' }, { val: 'numeric|max:5' })
-    expect(validator.passes()).toBeTruthy()
+  it('should be failed when given string numeric', () => {
+    const validator = new Validator({ val: '6' }, { val: 'numeric|max:5' })
+    expect(validator.passes()).toBeFalsy()
   })
 
-  it('should be passed when given string as phone number', () => {
+  it('should be failed when given value over max', () => {
     const validator = new Validator(
-      { val: '01234567890' },
-      { val: 'numeric|max:11' },
+      { val: '100.1' },
+      { val: 'numeric|max:100' },
     )
-    expect(validator.passes()).toBeTruthy()
+    expect(validator.fails()).toBeTruthy()
+    expect(validator.passes()).toBeFalsy()
   })
 
   it('should be failed when given string as phone number over max', () => {

--- a/__tests__/min.spec.ts
+++ b/__tests__/min.spec.ts
@@ -77,7 +77,7 @@ describe('min validation rule', () => {
   it('should be failed when given string as phone number lower than min', () => {
     const validator = new Validator(
       { val: '0123456789' },
-      { val: 'numeric|min:11' },
+      { val: 'digits|min:11' },
     )
     expect(validator.fails()).toBeTruthy()
   })

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -7,7 +7,7 @@ const config: InitialOptionsTsJest = {
     global: {
       lines: 100,
       functions: 100,
-      branches: 97.76,
+      branches: 99.32,
       statements: 100,
     },
   },

--- a/src/rule.ts
+++ b/src/rule.ts
@@ -147,9 +147,7 @@ export class Rule {
       after_or_equal(val: string, req: string) {
         const val1 = this.validator.input[req]
         const val2 = val
-        if (!isValidDate(val1) || !isValidDate(val2)) {
-          return false
-        }
+        if (!isValidDate(val1) || !isValidDate(val2)) return false
         return new Date(val1).getTime() <= new Date(val2).getTime()
       },
       required_if(val: Record<string, any>, req: string[]) {
@@ -178,9 +176,7 @@ export class Rule {
         req = this.getParameters()
 
         for (const re of req) {
-          if (!objectPath(this.validator.input, re)) {
-            return true
-          }
+          if (!objectPath(this.validator.input, re)) return true
         }
 
         return this.validator.getRule('required').validate(val, {})

--- a/src/rule.ts
+++ b/src/rule.ts
@@ -1,12 +1,6 @@
 import Validator from './main'
 import * as rules from './rules'
-import {
-  flattenObject,
-  isEmpty,
-  isFloat,
-  isValidDate,
-  objectPath,
-} from './utils'
+import { flattenObject, isEmpty, isValidDate, objectPath } from './utils'
 
 let missedRuleValidator: VoidFunction = function (this: Rule) {
   throw new Error('Validator `' + this.name + '` is not defined!')
@@ -140,7 +134,6 @@ export class Rule {
   }
 
   static _setRules() {
-    const numericRules = ['numeric']
     Rule.rules = {
       ...this.rules,
       after(value: string, req: string) {
@@ -218,20 +211,10 @@ export class Rule {
       },
       min(val: string, req: number | string) {
         const size: number = this.getSize(val)
-        const numericRule = this.validator.getRule('numeric')
-        const hasNumeric = this.validator._hasRule(this.attribute, numericRules)
-        if (numericRule.validate(val, {}) && hasNumeric && !isFloat(val)) {
-          return String(val).trim().length >= parseInt(req as string)
-        }
         return size >= req
       },
       max(val: string, req: number | string) {
         const size: number = this.getSize(val)
-        const numericRule = this.validator.getRule('numeric')
-        const hasNumeric = this.validator._hasRule(this.attribute, numericRules)
-        if (numericRule.validate(val, {}) && hasNumeric && !isFloat(val)) {
-          return String(val).trim().length <= parseInt(req as string)
-        }
         return size <= req
       },
       between(val: string, req: string[]) {
@@ -251,7 +234,6 @@ export class Rule {
       },
       in(val: string | string[]) {
         let list: (string | number)[] = []
-        let i
         if (!isEmpty(val)) {
           list = this.getParameters()
         }
@@ -354,8 +336,8 @@ export class Manager {
 
   make(name: string, validator: Validator) {
     Rule._setRules()
-    const async = this.isAsync(name)
-    const rule = new Rule(name, Rule.rules[name], async)
+    const isAsync = this.isAsync(name)
+    const rule = new Rule(name, Rule.rules[name], isAsync)
     rule.setValidator(validator)
     return rule
   }

--- a/src/rules/ipv6.ts
+++ b/src/rules/ipv6.ts
@@ -21,11 +21,11 @@ export const ipv6 = (value: string | number) => {
     return false
 
   // check 3: ipv6 should contain no less than 3 sector
-  // minimum ipv6 addres - ::1
+  // minimum ipv6 address - ::1
   if (3 > hextets.length) return false
 
   // check 4: ipv6 should contain no more than 8 sectors
-  // only 1 edge case: when first or last sector is ommited
+  // only 1 edge case: when first or last sector is omitted
   const isEdgeCase =
     hextets.length == 9 &&
     colons != null &&
@@ -43,7 +43,7 @@ export const ipv6 = (value: string | number) => {
     // check 6: all of hextets should contain numbers from 0 to f (in hexadecimal)
     if (!er.test(element)) return false
 
-    // check 7: all of hextet values should be less than ffff (in hexadeimal)
+    // check 7: all of hextet values should be less than ffff (in hexadecimal)
     // checking using length of hextet. lowest invalid value's length is 5.
     // so all valid hextets are length of 4 or less
     if (element.length > 4) return false

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -13,12 +13,3 @@ export function onlyDigits(str: string | boolean | number) {
   const num = Number(str)
   return !isNaN(num) && typeof str !== 'boolean'
 }
-export function isFloat(n: string | number, shouldCoerce = true) {
-  if (shouldCoerce) {
-    if (typeof n === 'string') {
-      n = parseFloat(n)
-    }
-  }
-
-  return n === +n && n !== (n | 0)
-}


### PR DESCRIPTION
Fixed: #293 

- make the `numeric|min:5` works with number count, not length.